### PR TITLE
Remove yml and yaml from path filters

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -101,8 +101,6 @@ inputs:
       !**/*.pb.go
       !**/*.lock
       !**/*.ttf
-      !**/*.yaml
-      !**/*.yml
       !**/*.cfg
       !**/*.toml
       !**/*.ini


### PR DESCRIPTION
## Description
Remove `.yml` and `.yaml` from path filters.
Ansible and for example Symfony use it for configuration and for us its worth to have it enabled by default.

If configs shouldn't be reviewed, override the path filters for the specifc project.