### PR TITLE
Use gpt-4-turbo-preview model

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   review_simple_changes:
     required: false
     description: 'Review even when the changes are simple'
-    default: 'true'
+    default: 'false'
   review_comment_lgtm:
     required: false
     description: 'Leave comments even if the patch is LGTM'
@@ -156,7 +156,7 @@ inputs:
   openai_heavy_model:
     required: false
     description: 'Model to use for complex tasks such as code reviews.'
-    default: 'gpt-3.5-turbo'
+    default: 'gpt-4-turbo-preview'
   openai_model_temperature:
     required: false
     description: 'Temperature for GPT model'

--- a/src/limits.ts
+++ b/src/limits.ts
@@ -6,19 +6,30 @@ export class TokenLimits {
 
   constructor(model = 'gpt-3.5-turbo') {
     this.knowledgeCutOff = '2021-09-01'
-    if (model === 'gpt-4-32k') {
-      this.maxTokens = 32600
-      this.responseTokens = 4000
-    } else if (model === 'gpt-3.5-turbo-16k') {
-      this.maxTokens = 16300
-      this.responseTokens = 3000
-    } else if (model === 'gpt-4') {
-      this.maxTokens = 8000
-      this.responseTokens = 2000
-    } else {
-      this.maxTokens = 4000
-      this.responseTokens = 1000
+    switch (model) {
+      case 'gpt-4-32k':
+        this.maxTokens = 32600
+        this.responseTokens = 4000
+        break
+      case 'gpt-3.5-turbo-16k':
+        this.maxTokens = 16300
+        this.responseTokens = 3000
+        break
+      case 'gpt-4':
+        this.maxTokens = 8000
+        this.responseTokens = 2000
+        break
+      case 'gpt-4-turbo-preview':
+        this.maxTokens = 128000
+        this.responseTokens = 4000
+        this.knowledgeCutOff = '2023-12-01'
+        break
+      default:
+        this.maxTokens = 4000
+        this.responseTokens = 1000
+        break
     }
+
     // provide some margin for the request tokens
     this.requestTokens = this.maxTokens - this.responseTokens - 100
   }


### PR DESCRIPTION
Support gpt-4-turbo-preview as heavy model. This is cheaper than gpt-4 and provides a huge context.